### PR TITLE
Various small fixes and improvements

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -65,6 +65,11 @@ to ``fast``. And afterwards if the preferred encoding is not available for that
 quality, it will fallback to using ``mp3``.
 It seems that all channels support the combination ``fast`` + ``mp3``
 
+You can also choose to use the channel DJ as the reported track artist (default behavior)::
+
+    [somafm]
+    dj_as_artist = true
+
 
 Project resources
 =================

--- a/mopidy_somafm/__init__.py
+++ b/mopidy_somafm/__init__.py
@@ -22,6 +22,7 @@ class Extension(ext.Extension):
         schema['encoding'] = config.String(choices=('aac', 'mp3', 'aacp'))
         schema['quality'] = config.String(
             choices=('highest', 'fast', 'slow', 'firewall'))
+        schema['dj_as_artist'] = config.Boolean()
         return schema
 
     def validate_environment(self):

--- a/mopidy_somafm/actor.py
+++ b/mopidy_somafm/actor.py
@@ -51,7 +51,6 @@ class SomaFMLibraryProvider(backend.LibraryProvider):
         # Build album (idem as playlist, but with more metada)
         album = Album(
             artists=[artist],
-            date=channel_data['updated'],
             images=[channel_data['image']],
             name=channel_data['title'],
             uri='somafm:channel:/%s' % (channel_name))
@@ -59,6 +58,7 @@ class SomaFMLibraryProvider(backend.LibraryProvider):
         track = Track(
             artists=[artist],
             album=album,
+            last_modified=channel_data['updated'],
             comment=channel_data['description'],
             genre=channel_data['genre'],
             name=channel_data['title'],

--- a/mopidy_somafm/actor.py
+++ b/mopidy_somafm/actor.py
@@ -59,6 +59,7 @@ class SomaFMLibraryProvider(backend.LibraryProvider):
         track = Track(
             artists=[artist],
             album=album,
+            comment=channel_data['description'],
             genre=channel_data['genre'],
             name=channel_data['title'],
             uri=channel_data['pls'])

--- a/mopidy_somafm/actor.py
+++ b/mopidy_somafm/actor.py
@@ -77,5 +77,5 @@ class SomaFMLibraryProvider(backend.LibraryProvider):
                 name=self.backend.somafm.channels[channel]['title']
                 ))
 
-        result.sort(key=lambda ref: ref.name)
+        result.sort(key=lambda ref: ref.name.lower())
         return result

--- a/mopidy_somafm/actor.py
+++ b/mopidy_somafm/actor.py
@@ -26,6 +26,7 @@ class SomaFMBackend(pykka.ThreadingActor, backend.Backend):
         self.uri_schemes = ['somafm']
         self.quality = config['somafm']['quality']
         self.encoding = config['somafm']['encoding']
+        self.dj_as_artist = config['somafm']['dj_as_artist']
 
     def on_start(self):
         self.somafm.refresh(self.encoding, self.quality)
@@ -46,7 +47,10 @@ class SomaFMLibraryProvider(backend.LibraryProvider):
         channel_data = self.backend.somafm.channels[channel_name]
 
         # Artists
-        artist = Artist(name=channel_data['dj'])
+        if self.backend.dj_as_artist:
+            artist = Artist(name=channel_data['dj'])
+        else:
+            artist = Artist()
 
         # Build album (idem as playlist, but with more metada)
         album = Album(

--- a/mopidy_somafm/actor.py
+++ b/mopidy_somafm/actor.py
@@ -33,7 +33,7 @@ class SomaFMBackend(pykka.ThreadingActor, backend.Backend):
 
 class SomaFMLibraryProvider(backend.LibraryProvider):
 
-    root_directory = Ref.directory(uri='somafm:root', name='Soma FM')
+    root_directory = Ref.directory(uri='somafm:root', name='SomaFM')
 
     def lookup(self, uri):
         # Whatever the uri, it will always contains one track

--- a/mopidy_somafm/ext.conf
+++ b/mopidy_somafm/ext.conf
@@ -2,3 +2,4 @@
 enabled = true
 encoding = mp3
 quality = fast
+dj_as_artist = true

--- a/mopidy_somafm/somafm.py
+++ b/mopidy_somafm/somafm.py
@@ -8,7 +8,6 @@ import re
 import requests
 import urlparse
 import collections
-from datetime import datetime
 
 try:
     import xml.etree.cElementTree as ET
@@ -76,8 +75,7 @@ class SomaFMClient(object):
                 if key in ['title', 'image', 'dj', 'genre', 'description']:
                     channel_data[key] = val
                 elif key == 'updated':
-                    channel_data['updated'] = datetime.fromtimestamp(
-                        int(val)).strftime("%Y-%m-%d")
+                    channel_data['updated'] = int(val)
                 elif 'pls' in key:
                     pls_quality = key[:-3]
                     pls_format = child_detail.attrib['format']

--- a/mopidy_somafm/somafm.py
+++ b/mopidy_somafm/somafm.py
@@ -73,7 +73,7 @@ class SomaFMClient(object):
                 key = child_detail.tag
                 val = child_detail.text
 
-                if key in ['title', 'image', 'dj', 'genre']:
+                if key in ['title', 'image', 'dj', 'genre', 'description']:
                     channel_data[key] = val
                 elif key == 'updated':
                     channel_data['updated'] = datetime.fromtimestamp(


### PR DESCRIPTION
These PR introduces various small fixes and improvements described in their own commit message

The main change adds a new setting `dj_as_artist` to choose whether the DJ name should be used as artist name. The problem encountered is that in some mopidy client (for example I'm using ncmpcpp), the display of the artist clutters the list uselessly.

The default behavior is unchanged (the artist name is set to the DJ one)
If you don't like this new config, another option could be to set the DJ name to another track field (like composer or performer) so you keep the DJ information but it is not getting displayed by default.