### PR TITLE
Channel fallback pls

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -41,7 +41,7 @@ The extension requires that the Mopidy-Stream extension is enabled. It is
 bundled with Mopidy and enabled by default, so it will be available unless
 you've explicitly disabled it.
 
-You may change prefered quality and encoding in your Mopidy configuration file::
+You may change preferred quality and encoding in your Mopidy configuration file::
 
     [somafm]
     encoding = aac
@@ -50,15 +50,10 @@ You may change prefered quality and encoding in your Mopidy configuration file::
 - ``encoding`` must be either ``aac``, ``mp3`` or ``aacp``
 - ``quality`` must be one of ``highest``, ``fast``, ``slow``, ``firewall``
 
-
-Warning
-=======
-
-SomaFM does not provide every possible combination of ``encoding`` and ``quality``.
-
-For example, as of 2015/06/03, ``mp3 + highest`` gives only 3 playlists while ``aac + highest`` gives 15 and ``mp3 + fast`` gives 30.
-
-Some combinations are incompatible and will give zero playlist: ``aacp + highest`` and ``aac + fast``.
+If the preferred quality is not available for a channel, the extension will fallback
+to ``fast``. And afterwards if the preferred encoding is not available for that
+quality, it will fallback to using ``mp3``.
+It seems that all channels support the combination ``fast`` + ``mp3``
 
 
 Project resources

--- a/mopidy_somafm/__init__.py
+++ b/mopidy_somafm/__init__.py
@@ -4,7 +4,7 @@ import os
 
 from mopidy import config, ext
 
-__version__ = '1.0.0'
+__version__ = '1.0.1'
 
 
 class Extension(ext.Extension):

--- a/mopidy_somafm/somafm.py
+++ b/mopidy_somafm/somafm.py
@@ -7,6 +7,7 @@ import logging
 import re
 import requests
 import urlparse
+import collections
 from datetime import datetime
 
 try:
@@ -29,6 +30,11 @@ logger = logging.getLogger(__name__)
 class SomaFMClient(object):
 
     CHANNELS_URI = "https://api.somafm.com/channels.xml"
+
+    # All channels seem to have this combination of quality/encoding available
+    FALLBACK_QUALITY = "fast"
+    FALLBACK_ENCODING = "mp3"
+
     channels = {}
 
     def __init__(self, proxy_config=None, user_agent=None):
@@ -47,11 +53,6 @@ class SomaFMClient(object):
         # clean previous data
         self.channels = {}
 
-        # adjust quality real name
-        plsquality = quality
-        if plsquality != 'firewall':
-            plsquality += 'pls'
-
         # download channels xml file
         channels_content = self._downloadContent(self.CHANNELS_URI)
         if channels_content is None:
@@ -65,6 +66,7 @@ class SomaFMClient(object):
 
             pls_id = child_channel.attrib['id']
             channel_data = {}
+            channel_all_pls = collections.defaultdict(dict)
 
             for child_detail in child_channel:
 
@@ -77,19 +79,21 @@ class SomaFMClient(object):
                     channel_data['updated'] = datetime.fromtimestamp(
                         int(val)).strftime("%Y-%m-%d")
                 elif 'pls' in key:
-                    plsformat = child_detail.attrib['format']
+                    pls_quality = key[:-3]
+                    pls_format = child_detail.attrib['format']
 
-                    if (key == plsquality and plsformat == encoding):
-                        channel_data['pls'] = val
+                    channel_all_pls[pls_quality][pls_format] = val
+
                     # firewall playlist are fastpls+mp3 but with fw path
-                    elif (
-                            plsquality == 'firewall' and
-                            key == 'fastpls' and plsformat == 'mp3'):
+                    if pls_quality == 'fast' and pls_format == 'mp3':
                         r1 = urlparse.urlsplit(val)
-                        channel_data['pls'] = "%s://%s/%s" % (
+                        channel_all_pls['firewall']['mp3'] = "%s://%s/%s" % (
                             r1.scheme, r1.netloc, 'fw' + r1.path)
 
-            if 'pls' in channel_data:
+            channel_pls = self._choose_pls(channel_all_pls, encoding, quality)
+
+            if channel_pls is not None:
+                channel_data['pls'] = channel_pls
                 self.channels[pls_id] = channel_data
 
         logger.info('Loaded %i SomaFM channels' % (len(self.channels)))
@@ -111,6 +115,29 @@ class SomaFMClient(object):
                 return pls_uri
         except:
             return pls_uri
+
+    def _choose_pls(self, all_pls, encoding, quality):
+        if not all_pls:
+            return None
+
+        if quality in all_pls:
+            quality_pls = all_pls[quality]
+        elif self.FALLBACK_QUALITY in all_pls:
+            quality_pls = all_pls[self.FALLBACK_QUALITY]
+        else:
+            quality_pls = all_pls[next(iter(all_pls))]
+
+        if not quality_pls:
+            return None
+
+        if encoding in quality_pls:
+            pls = quality_pls[encoding]
+        elif self.FALLBACK_ENCODING in all_pls:
+            pls = quality_pls[self.FALLBACK_ENCODING]
+        else:
+            pls = quality_pls[next(iter(quality_pls))]
+
+        return pls
 
     def _downloadContent(self, url):
         try:


### PR DESCRIPTION
This fixes #24 

It is not really a full "graceful degradation" but it introduces a fallback mechanism so that no SomaFM channel gets lost. All  of them stay available.

A real "graceful degradation" implementation would be more complex in terms of code while this is relatively simple.
It is a similar fallback as I used in one my app https://github.com/tardypad/sailfishos-somafm/blob/master/src/Player.cpp#L187

The config doesn't change at all