### PR TITLE
Port to v4.0.0

### DIFF
--- a/mopidy_somafm/__init__.py
+++ b/mopidy_somafm/__init__.py
@@ -1,11 +1,11 @@
 import logging
 import pathlib
 
-import pkg_resources
+from importlib.metadata import distribution
 
 from mopidy import config, ext
 
-__version__ = pkg_resources.get_distribution("Mopidy-SomaFM").version
+__version__ = distribution("Mopidy-SomaFM").version
 
 logger = logging.getLogger(__name__)
 

--- a/mopidy_somafm/backend.py
+++ b/mopidy_somafm/backend.py
@@ -2,7 +2,7 @@ import logging
 
 import mopidy_somafm
 import pykka
-import requests
+import httpx
 import configparser
 import random
 from mopidy import backend, httpclient
@@ -110,14 +110,13 @@ class SomaFMPlayback(backend.PlaybackProvider):
     def __init__(self, audio, backend, proxy_config=None, user_agent=None):
         super().__init__(audio=audio, backend=backend)
 
-        # Build requests session
-        self.session = requests.Session()
-        if proxy_config is not None:
-            proxy = httpclient.format_proxy(proxy_config)
-            self.session.proxies.update({"http": proxy, "https": proxy})
-
-        full_user_agent = httpclient.format_user_agent(user_agent)
-        self.session.headers.update({"user-agent": full_user_agent})
+        # Build HTTP client
+        self.http = httpx.Client(
+            proxy=httpclient.format_proxy(proxy_config),
+            headers={
+                "user-agent": httpclient.format_user_agent(user_agent)
+            }
+        )
 
     def translate_uri(self, uri):
         try:
@@ -127,7 +126,7 @@ class SomaFMPlayback(backend.PlaybackProvider):
 
             channel_data = self.backend.somafm.channels.get(channel_name)
 
-            r = self.session.get(channel_data["pls"])
+            r = self.http.get(channel_data["pls"])
             if r.status_code != 200:
                 return None
 

--- a/mopidy_somafm/somafm.py
+++ b/mopidy_somafm/somafm.py
@@ -3,7 +3,7 @@ import logging
 import re
 from urllib.parse import urlsplit
 
-import requests
+import httpx
 
 from mopidy import httpclient
 
@@ -48,14 +48,13 @@ class SomaFMClient:
     def __init__(self, proxy_config=None, user_agent=None):
         super().__init__()
 
-        # Build requests session
-        self.session = requests.Session()
-        if proxy_config is not None:
-            proxy = httpclient.format_proxy(proxy_config)
-            self.session.proxies.update({"http": proxy, "https": proxy})
-
-        full_user_agent = httpclient.format_user_agent(user_agent)
-        self.session.headers.update({"user-agent": full_user_agent})
+        # Build HTTP client
+        self.http = httpx.Client(
+            proxy=httpclient.format_proxy(proxy_config),
+            headers={
+                "user-agent": httpclient.format_user_agent(user_agent)
+            }
+        )
 
     def refresh(self, encoding, quality):
         # clean previous data
@@ -150,7 +149,7 @@ class SomaFMClient:
 
     def _downloadContent(self, url):
         try:
-            r = self.session.get(url)
+            r = self.http.get(url)
             logger.debug("Get %s : %i", url, r.status_code)
 
             if r.status_code != 200:
@@ -161,14 +160,8 @@ class SomaFMClient:
                 )
                 return None
 
-        except requests.exceptions.RequestException as e:
-            logger.error("SomaFM RequestException: %s", e)
-        except requests.exceptions.ConnectionError as e:
-            logger.error("SomaFM ConnectionError: %s", e)
-        except requests.exceptions.URLRequired as e:
-            logger.error("SomaFM URLRequired: %s", e)
-        except requests.exceptions.TooManyRedirects as e:
-            logger.error("SomaFM TooManyRedirects: %s", e)
+        except httpx.RequestError as e:
+            logger.error("SomaFM RequestError: %s", e)
         except Exception as e:
             logger.error("SomaFM exception: %s", e)
         else:


### PR DESCRIPTION
Starting with Python 3.8 `importlib` has been introduced that deprecates `pkg_resources`. And Mopidy >= 4 uses `httpx` in place of `requests`.